### PR TITLE
モバイル表示の改善: 編集/削除ボタン非表示、行タップで編集、期日列拡大

### DIFF
--- a/components/TaskBoard.tsx
+++ b/components/TaskBoard.tsx
@@ -736,7 +736,7 @@ export default function TaskBoard({ initialTasks, initialCollapsedIds, initialTh
                 />
               </th>
               <th
-                className={`text-left py-1.5 px-1 font-medium text-text-secondary relative${colWidths.due == null ? ' w-14 sm:w-36' : ''}`}
+                className={`text-left py-1.5 px-1 font-medium text-text-secondary relative${colWidths.due == null ? ' w-28 sm:w-36' : ''}`}
                 style={colWidths.due != null ? { width: colWidths.due } : undefined}
               >
                 期日
@@ -768,8 +768,8 @@ export default function TaskBoard({ initialTasks, initialCollapsedIds, initialTh
                   style={{ right: -2, width: 5 }}
                 />
               </th>
-              <th className="w-8"></th>
-              <th className="w-8"></th>
+              <th className="hidden sm:table-cell w-8"></th>
+              <th className="hidden sm:table-cell w-8"></th>
             </tr>
           </thead>
           <tbody>
@@ -807,7 +807,8 @@ export default function TaskBoard({ initialTasks, initialCollapsedIds, initialTh
                         <td></td>
                         <td className="hidden sm:table-cell"></td>
                         <td className="hidden sm:table-cell"></td>
-                        <td colSpan={2}></td>
+                        <td className="hidden sm:table-cell"></td>
+                        <td className="hidden sm:table-cell"></td>
                       </tr>
                     ))}
                   </Fragment>
@@ -828,7 +829,8 @@ export default function TaskBoard({ initialTasks, initialCollapsedIds, initialTh
                     <td></td>
                     <td className="hidden sm:table-cell"></td>
                     <td className="hidden sm:table-cell"></td>
-                    <td colSpan={2}></td>
+                    <td className="hidden sm:table-cell"></td>
+                    <td className="hidden sm:table-cell"></td>
                   </tr>
                 )}
           </tbody>

--- a/components/TaskEditDialog.tsx
+++ b/components/TaskEditDialog.tsx
@@ -10,6 +10,7 @@ interface TaskEditDialogProps {
   open: boolean
   onClose: () => void
   onSave: (updates: Partial<Task>) => void
+  onDelete?: () => void
 }
 
 const TIME_UNITS: { value: TimeUnit; label: string }[] = [
@@ -19,7 +20,7 @@ const TIME_UNITS: { value: TimeUnit; label: string }[] = [
   { value: 'mo', label: 'mo' },
 ]
 
-export default function TaskEditDialog({ task, open, onClose, onSave }: TaskEditDialogProps) {
+export default function TaskEditDialog({ task, open, onClose, onSave, onDelete }: TaskEditDialogProps) {
   const [name, setName] = useState(task.name)
   const [dueType, setDueType] = useState<DueType>(task.due_type)
   const [dueDate, setDueDate] = useState(task.due_date ?? '')
@@ -181,19 +182,29 @@ export default function TaskEditDialog({ task, open, onClose, onSave }: TaskEdit
             </div>
           </div>
 
-          <div className="flex justify-end gap-2 mt-6">
-            <button
-              onClick={onClose}
-              className="px-4 py-2 text-sm border border-border-default rounded text-text-secondary hover:bg-surface-raised transition-all active:scale-[0.97]"
-            >
-              キャンセル
-            </button>
-            <button
-              onClick={handleSave}
-              className="px-4 py-2 text-sm btn-gradient rounded"
-            >
-              保存
-            </button>
+          <div className="flex justify-between mt-6">
+            {onDelete ? (
+              <button
+                onClick={onDelete}
+                className="px-4 py-2 text-sm border border-danger-muted rounded text-danger hover:bg-danger-muted transition-all active:scale-[0.97]"
+              >
+                削除
+              </button>
+            ) : <span />}
+            <div className="flex gap-2">
+              <button
+                onClick={onClose}
+                className="px-4 py-2 text-sm border border-border-default rounded text-text-secondary hover:bg-surface-raised transition-all active:scale-[0.97]"
+              >
+                キャンセル
+              </button>
+              <button
+                onClick={handleSave}
+                className="px-4 py-2 text-sm btn-gradient rounded"
+              >
+                保存
+              </button>
+            </div>
           </div>
         </Dialog.Content>
       </Dialog.Portal>

--- a/components/TaskRow.tsx
+++ b/components/TaskRow.tsx
@@ -63,6 +63,13 @@ export default memo(function TaskRow({
 
   const indent = (task.level - 1) * 20 // px per level
 
+  const handleRowClick = (e: React.MouseEvent<HTMLTableRowElement>) => {
+    // インタラクティブ要素のクリックは無視
+    const target = e.target as HTMLElement
+    if (target.closest('button, input, select, textarea, a, [role="button"], [contenteditable]')) return
+    setEditDialogOpen(true)
+  }
+
   const handleRowKeyDown = (e: React.KeyboardEvent) => {
     if (e.ctrlKey && e.key === 'ArrowRight') {
       e.preventDefault()
@@ -91,8 +98,9 @@ export default memo(function TaskRow({
       <tr
         ref={setNodeRef}
         style={style}
-        className={`border-b border-border-subtle group transition-[background-color,box-shadow] duration-150 ease-out hover:bg-surface-raised hover:shadow-[0_2px_8px_rgba(0,0,0,0.3)] ${isDragging ? 'bg-accent-muted shadow-lg' : ''}`}
+        className={`border-b border-border-subtle group transition-[background-color,box-shadow] duration-150 ease-out hover:bg-surface-raised hover:shadow-[0_2px_8px_rgba(0,0,0,0.3)] cursor-pointer sm:cursor-default ${isDragging ? 'bg-accent-muted shadow-lg' : ''}`}
         onKeyDown={handleRowKeyDown}
+        onClick={handleRowClick}
       >
         {/* ドラッグハンドル */}
         <td className="w-6 py-1 pl-1 text-text-tertiary hover:text-text-secondary cursor-grab active:cursor-grabbing transition-colors" {...dragProps}>
@@ -149,7 +157,7 @@ export default memo(function TaskRow({
         </td>
 
         {/* 期日 */}
-        <td className="py-1 w-14 sm:w-36">
+        <td className="py-1 w-28 sm:w-36">
           <DueDateSelect
             dueType={task.due_type}
             dueDate={task.due_date}
@@ -185,8 +193,8 @@ export default memo(function TaskRow({
           </span>
         </td>
 
-        {/* 編集ボタン */}
-        <td className="py-1 w-8">
+        {/* 編集ボタン（モバイルでは非表示） */}
+        <td className="hidden sm:table-cell py-1 w-8">
           <button
             onClick={() => setEditDialogOpen(true)}
             className="text-text-tertiary hover:text-accent-solid transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100 p-0.5"
@@ -200,8 +208,8 @@ export default memo(function TaskRow({
           </button>
         </td>
 
-        {/* 削除ボタン */}
-        <td className="py-1 w-8">
+        {/* 削除ボタン（モバイルでは非表示） */}
+        <td className="hidden sm:table-cell py-1 w-8">
           <button
             onClick={() => onDelete(task.id)}
             className="text-text-tertiary hover:text-danger transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100 p-0.5"
@@ -222,6 +230,7 @@ export default memo(function TaskRow({
           open={editDialogOpen}
           onClose={() => setEditDialogOpen(false)}
           onSave={updates => onUpdate(task.id, updates)}
+          onDelete={() => { setEditDialogOpen(false); onDelete(task.id) }}
         />
       )}
     </>


### PR DESCRIPTION
- モバイルで編集ボタンと削除ボタンを非表示にし、期日列をつめる
- 期日列の幅をモバイルでw-14からw-28に拡大（約2倍）
- 行タップで編集フォームが開くようにする（インタラクティブ要素は除外）
- 編集フォームに削除ボタンを追加

https://claude.ai/code/session_01DnhfXtTTQNao34bitCdxMS