### PR TITLE
Implement pending task state for deferred task creation

### DIFF
--- a/components/InlineEdit.tsx
+++ b/components/InlineEdit.tsx
@@ -10,6 +10,7 @@ interface InlineEditProps {
   isFocused?: boolean
   onFocus?: () => void
   onBlur?: () => void
+  onBlurEmpty?: () => void
   onArrowUp?: () => void
   onArrowDown?: () => void
 }
@@ -22,6 +23,7 @@ export default function InlineEdit({
   isFocused = false,
   onFocus,
   onBlur,
+  onBlurEmpty,
   onArrowUp,
   onArrowDown,
 }: InlineEditProps) {
@@ -44,7 +46,10 @@ export default function InlineEdit({
     if (draft !== value) {
       onSave(draft)
     }
-  }, [draft, value, onSave])
+    if (!draft.trim()) {
+      onBlurEmpty?.()
+    }
+  }, [draft, value, onSave, onBlurEmpty])
 
   const cancelEdit = useCallback(() => {
     setDraft(value)

--- a/components/TaskBoard.tsx
+++ b/components/TaskBoard.tsx
@@ -46,6 +46,7 @@ export default function TaskBoard({ initialTasks, initialCollapsedIds, initialTh
   const [collapsedIds, setCollapsedIds] = useState<Set<string>>(() => new Set(initialCollapsedIds))
   const [theme, setTheme] = useState<'dark' | 'light'>(initialTheme)
   const [lastOperatedPerProject, setLastOperatedPerProject] = useState<Map<string, string>>(new Map())
+  const [pendingTaskIds, setPendingTaskIds] = useState<Set<string>>(new Set())
   const headerRef = useRef<HTMLDivElement>(null)
   const [headerHeight, setHeaderHeight] = useState(0)
   const supabase = createClient()
@@ -204,9 +205,50 @@ export default function TaskBoard({ initialTasks, initialCollapsedIds, initialTh
 
   // ─── タスク更新 ──────────────────────────────────────────────────────
   const handleUpdate = useCallback(async (id: string, updates: Partial<Task>) => {
+    if (pendingTaskIds.has(id)) {
+      if ('name' in updates) {
+        const name = updates.name ?? ''
+        if (!name.trim()) {
+          setTasks(prev => prev.filter(t => t.id !== id))
+          setPendingTaskIds(prev => { const next = new Set(prev); next.delete(id); return next })
+          return
+        }
+        const localTask = tasks.find(t => t.id === id)
+        if (!localTask) return
+        const { id: _id, created_at: _ca, updated_at: _ua, ...insertBase } = localTask
+        const insertData = { ...insertBase, ...updates }
+        const { data, error } = await supabase.from('tasks').insert(insertData).select().single()
+        if (!error && data) {
+          const realTask = data as Task
+          setTasks(prev => prev.map(t => t.id === id ? realTask : t))
+          setFocusedId(prev => prev === id ? realTask.id : prev)
+          setPendingTaskIds(prev => { const next = new Set(prev); next.delete(id); return next })
+          if (realTask.level >= 2) {
+            let rootTask = realTask.parent_id ? tasks.find(t => t.id === realTask.parent_id) : null
+            while (rootTask && rootTask.level > 1 && rootTask.parent_id) {
+              const parent = tasks.find(t => t.id === rootTask!.parent_id)
+              if (!parent) break
+              rootTask = parent
+            }
+            if (rootTask?.level === 1) {
+              const projectId = rootTask.id
+              setLastOperatedPerProject(prev => {
+                const next = new Map(prev)
+                for (const [k, v] of next) { if (v === id) next.set(k, realTask.id) }
+                next.set(projectId, realTask.id)
+                return next
+              })
+            }
+          }
+        }
+        return
+      }
+      setTasks(prev => prev.map(t => t.id === id ? { ...t, ...updates } : t))
+      return
+    }
     setTasks(prev => prev.map(t => t.id === id ? { ...t, ...updates } : t))
     await supabase.from('tasks').update(updates).eq('user_id', userId).eq('id', id)
-  }, [supabase, userId])
+  }, [pendingTaskIds, tasks, supabase, userId])
 
   // ─── 完了切り替え（子タスクにカスケード） ────────────────────────────
   const handleToggleComplete = useCallback(async (id: string, completed: boolean) => {
@@ -230,7 +272,13 @@ export default function TaskBoard({ initialTasks, initialCollapsedIds, initialTh
   }, [tasks, supabase, userId])
 
   // ─── タスク追加 ──────────────────────────────────────────────────────
-  const handleAdd = useCallback(async (parentId: string | null, level: number, afterTaskId?: string) => {
+  const handleAdd = useCallback((parentId: string | null, level: number, afterTaskId?: string) => {
+    // 未確定の空タスクが残っていれば破棄してから追加する
+    if (pendingTaskIds.size > 0) {
+      setTasks(prev => prev.filter(t => !pendingTaskIds.has(t.id)))
+      setPendingTaskIds(new Set())
+    }
+
     // 同じ親の兄弟タスクを取得して position を決める
     const siblings = tasks.filter(t => t.parent_id === parentId && !t.archived).sort((a, b) => a.position - b.position)
     let position: number
@@ -259,7 +307,13 @@ export default function TaskBoard({ initialTasks, initialCollapsedIds, initialTh
       ? `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`
       : null
 
-    const taskInput: Omit<Task, 'id' | 'created_at' | 'updated_at'> = {
+    // 名前が確定されるまでローカルのみに保持する一時タスク
+    const tempId = crypto.randomUUID()
+    const now = new Date().toISOString()
+    const tempTask: Task = {
+      id: tempId,
+      created_at: now,
+      updated_at: now,
       user_id: userId,
       parent_id: parentId,
       level,
@@ -277,35 +331,35 @@ export default function TaskBoard({ initialTasks, initialCollapsedIds, initialTh
       position,
     }
 
-    const { data, error } = await supabase
-      .from('tasks')
-      .insert(taskInput)
-      .select()
-      .single()
+    setTasks(prev => [...prev, tempTask])
+    setPendingTaskIds(prev => new Set([...prev, tempId]))
+    setTimeout(() => setFocusedId(tempId), 50)
 
-    if (!error && data) {
-      const newTask = data as Task
-      setTasks(prev => [...prev, newTask])
-      setTimeout(() => setFocusedId(newTask.id), 50)
-      // 新規追加したタスクを「最後に操作したタスク」として記録
-      if (newTask.level >= 2) {
-        let rootTask = parentId ? tasks.find(t => t.id === parentId) : null
-        while (rootTask && rootTask.level > 1 && rootTask.parent_id) {
-          const parent = tasks.find(t => t.id === rootTask!.parent_id)
-          if (!parent) break
-          rootTask = parent
-        }
-        if (rootTask?.level === 1) {
-          const projectId = rootTask.id
-          setLastOperatedPerProject(prev => {
-            const next = new Map(prev)
-            next.set(projectId, newTask.id)
-            return next
-          })
-        }
+    // 「最後に操作したタスク」としてアドボタンの位置決めに使う
+    if (level >= 2) {
+      let rootTask = parentId ? tasks.find(t => t.id === parentId) : null
+      while (rootTask && rootTask.level > 1 && rootTask.parent_id) {
+        const parent = tasks.find(t => t.id === rootTask!.parent_id)
+        if (!parent) break
+        rootTask = parent
+      }
+      if (rootTask?.level === 1) {
+        const projectId = rootTask.id
+        setLastOperatedPerProject(prev => {
+          const next = new Map(prev)
+          next.set(projectId, tempId)
+          return next
+        })
       }
     }
-  }, [tasks, userId, supabase])
+  }, [tasks, userId, pendingTaskIds])
+
+  // ─── 未確定の空タスクを破棄 ──────────────────────────────────────────
+  const handleAbandonTask = useCallback((id: string) => {
+    if (!pendingTaskIds.has(id)) return
+    setTasks(prev => prev.filter(t => t.id !== id))
+    setPendingTaskIds(prev => { const next = new Set(prev); next.delete(id); return next })
+  }, [pendingTaskIds])
 
   // ─── タスク削除（アーカイブ） ─────────────────────────────────────────
   const handleDelete = useCallback(async (id: string) => {
@@ -850,6 +904,7 @@ export default function TaskBoard({ initialTasks, initialCollapsedIds, initialTh
                       focusedColumn={focusedId === task.id ? focusedColumn : null}
                       onFocus={handleFocus}
                       onUpdate={handleUpdate}
+                      onAbandon={handleAbandonTask}
                       onDelete={handleDelete}
                       onToggleComplete={handleToggleComplete}
                       onLevelUp={handleLevelUp}

--- a/components/TaskRow.tsx
+++ b/components/TaskRow.tsx
@@ -17,6 +17,7 @@ interface TaskRowProps {
   focusedColumn: 'name' | 'due' | 'time' | 'checkbox' | null
   onFocus: (id: string, column: 'name' | 'due' | 'time' | 'checkbox') => void
   onUpdate: (id: string, updates: Partial<Task>) => void
+  onAbandon: (id: string) => void
   onDelete: (id: string) => void
   onToggleComplete: (id: string, completed: boolean) => void
   onLevelUp: (id: string) => void
@@ -33,6 +34,7 @@ export default memo(function TaskRow({
   focusedColumn,
   onFocus,
   onUpdate,
+  onAbandon,
   onDelete,
   onToggleComplete,
   onLevelUp,
@@ -151,6 +153,7 @@ export default memo(function TaskRow({
               onFocus={() => onFocus(task.id, 'name')}
               onArrowUp={() => onFocusPrev(task.id)}
               onArrowDown={() => onFocusNext(task.id)}
+              onBlurEmpty={() => onAbandon(task.id)}
               className={`truncate ${task.completed ? 'line-through text-text-tertiary' : ''}`}
             />
           </div>


### PR DESCRIPTION
## Summary
This PR introduces a "pending task" system that defers database insertion until a task name is confirmed. Tasks are now created locally first, and only persisted to the database when the user provides a non-empty name or performs another action.

## Key Changes
- **Added pending task tracking**: New `pendingTaskIds` state to track tasks awaiting name confirmation
- **Deferred task creation**: `handleAdd` now creates temporary local tasks instead of immediately inserting into the database
- **Conditional update logic**: `handleUpdate` detects pending tasks and handles them specially:
  - If a pending task receives a name, it's inserted into the database with the real ID
  - If a pending task receives other updates, they're applied locally only
  - Empty names trigger task abandonment
- **Task abandonment**: New `handleAbandonTask` callback removes pending tasks without database persistence
- **Enhanced InlineEdit**: Added `onBlurEmpty` callback to trigger abandonment when a field loses focus while empty
- **Updated TaskRow**: Passes `onAbandon` handler to the name field's InlineEdit component

## Implementation Details
- Pending tasks use temporary UUIDs and are marked in the `pendingTaskIds` Set
- When a pending task is named, it's inserted via Supabase and the temporary ID is replaced with the real one
- The "last operated task" tracking is updated to use the real task ID after insertion
- Cleanup of pending tasks occurs when adding new tasks or when names are confirmed/abandoned

https://claude.ai/code/session_01XxxEJh1TxcF4LkTSEzG4qG