### PR TITLE
Improve task insertion positioning for nested tasks

### DIFF
--- a/components/TaskBoard.tsx
+++ b/components/TaskBoard.tsx
@@ -756,12 +756,18 @@ export default function TaskBoard({ initialTasks, initialCollapsedIds, initialTh
       } else {
         // 折りたたまれて非表示の場合はデフォルト位置
         anchorId = defaultAnchorId
-        btn = { parentId: projectId, level: 2 }
+        const anchorTask = fullFlatList.find(t => t.id === defaultAnchorId)
+        btn = anchorTask && anchorTask.level >= 2
+          ? { parentId: anchorTask.parent_id, level: anchorTask.level, afterTaskId: defaultAnchorId }
+          : { parentId: projectId, level: 2 }
       }
     } else {
       // 未操作はデフォルト位置（ツリー末尾）
       anchorId = defaultAnchorId
-      btn = { parentId: projectId, level: 2 }
+      const anchorTask = fullFlatList.find(t => t.id === defaultAnchorId)
+      btn = anchorTask && anchorTask.level >= 2
+        ? { parentId: anchorTask.parent_id, level: anchorTask.level, afterTaskId: defaultAnchorId }
+        : { parentId: projectId, level: 2 }
     }
 
     const existing = addButtonsAfter.get(anchorId) ?? []


### PR DESCRIPTION
## Summary
Enhanced the task insertion logic to better handle positioning when inserting new tasks relative to nested/child tasks. Previously, new tasks were always inserted at the project level (level 2) when using default anchor positions. Now the system intelligently detects if the anchor task is nested and preserves its hierarchy context.

## Key Changes
- Modified task insertion logic in two code paths (collapsed/hidden tasks and untouched state) to check the anchor task's nesting level
- When the anchor task has a level >= 2 (indicating it's nested), new tasks are now inserted as siblings using the anchor task's parent and level, positioned after the anchor task
- Fallback behavior preserved: if anchor task is not found or is at root level, tasks are inserted at the default project level (level 2)

## Implementation Details
- Added lookup of the anchor task from `fullFlatList` to determine its hierarchy context
- New insertion parameters include `parentId` (from anchor task's parent), `level` (from anchor task), and `afterTaskId` (the anchor task itself) for nested insertions
- This ensures new tasks maintain proper tree structure when inserted relative to nested tasks, rather than always promoting them to the top level

https://claude.ai/code/session_01UdaArCLJJVritHxGQ7GLNw