### PR TITLE
fix: 新規タスクのタスク名が空の状態でEscapeを押すとタスクを破棄する (#10)

### DIFF
--- a/components/InlineEdit.tsx
+++ b/components/InlineEdit.tsx
@@ -11,6 +11,7 @@ interface InlineEditProps {
   onFocus?: () => void
   onBlur?: () => void
   onBlurEmpty?: () => void
+  onCancelEmpty?: () => void
   onArrowUp?: () => void
   onArrowDown?: () => void
 }
@@ -24,6 +25,7 @@ export default function InlineEdit({
   onFocus,
   onBlur,
   onBlurEmpty,
+  onCancelEmpty,
   onArrowUp,
   onArrowDown,
 }: InlineEditProps) {
@@ -54,7 +56,10 @@ export default function InlineEdit({
   const cancelEdit = useCallback(() => {
     setDraft(value)
     setEditing(false)
-  }, [value])
+    if (!value.trim()) {
+      onCancelEmpty?.()
+    }
+  }, [value, onCancelEmpty])
 
   useEffect(() => {
     if (editing && inputRef.current) {

--- a/components/TaskRow.tsx
+++ b/components/TaskRow.tsx
@@ -154,6 +154,7 @@ export default memo(function TaskRow({
               onArrowUp={() => onFocusPrev(task.id)}
               onArrowDown={() => onFocusNext(task.id)}
               onBlurEmpty={() => onAbandon(task.id)}
+              onCancelEmpty={() => onAbandon(task.id)}
               className={`truncate ${task.completed ? 'line-through text-text-tertiary' : ''}`}
             />
           </div>


### PR DESCRIPTION
InlineEdit に onCancelEmpty prop を追加し、value が空のときに Escape キーを 押すとコールバックを呼び出すように変更。TaskRow でこれを onAbandon に接続し、
未確定の空タスクを削除する。

https://claude.ai/code/session_015BPjvFwbhdAG822V4c8fud