### PR TITLE
fix: 新規タスクでEscapeを2回押すとタスク作成をキャンセルする (#10)

### DIFF
--- a/components/InlineEdit.tsx
+++ b/components/InlineEdit.tsx
@@ -56,10 +56,7 @@ export default function InlineEdit({
   const cancelEdit = useCallback(() => {
     setDraft(value)
     setEditing(false)
-    if (!value.trim()) {
-      onCancelEmpty?.()
-    }
-  }, [value, onCancelEmpty])
+  }, [value])
 
   useEffect(() => {
     if (editing && inputRef.current) {
@@ -94,7 +91,17 @@ export default function InlineEdit({
       commitEdit()
     } else if (e.key === 'Escape') {
       e.preventDefault()
-      cancelEdit()
+      if (!value.trim()) {
+        if (draft.trim()) {
+          // 1回目のEscape: 入力をクリアして編集継続
+          setDraft('')
+        } else {
+          // 2回目のEscape: 新規タスク作成をキャンセル
+          onCancelEmpty?.()
+        }
+      } else {
+        cancelEdit()
+      }
     }
   }
 


### PR DESCRIPTION
新規タスク（value が空）でのEscape動作を2段階に変更:
- 1回目: 入力内容をクリアして編集モード継続
- 2回目: onCancelEmpty を呼びタスクを破棄

既存タスクの編集中のEscapeは従来通り cancelEdit() を呼ぶ。

https://claude.ai/code/session_015BPjvFwbhdAG822V4c8fud