### PR TITLE
Limit task edit dialog to task name cell on desktop

### DIFF
--- a/components/TaskRow.tsx
+++ b/components/TaskRow.tsx
@@ -66,9 +66,13 @@ export default memo(function TaskRow({
   const indent = (task.level - 1) * 20 // px per level
 
   const handleRowClick = (e: React.MouseEvent<HTMLTableRowElement>) => {
-    // インタラクティブ要素のクリックは無視
     const target = e.target as HTMLElement
     if (target.closest('button, input, select, textarea, a, [role="button"], [contenteditable]')) return
+    // PCではタスク名セル（3列目）のクリックのみダイアログを開く
+    if (window.matchMedia('(min-width: 640px)').matches) {
+      const row = e.currentTarget as HTMLTableRowElement
+      if (!row.cells[2]?.contains(target)) return
+    }
     setEditDialogOpen(true)
   }
 


### PR DESCRIPTION
## Summary
Modified the task row click handler to restrict opening the edit dialog to only the task name cell (3rd column) on desktop devices, while maintaining the existing behavior on mobile.

## Key Changes
- Added responsive behavior to the `handleRowClick` function in TaskRow component
- On desktop (min-width: 640px), the edit dialog now only opens when clicking the task name cell (column index 2)
- Mobile devices retain the original behavior where clicking anywhere on the row (except interactive elements) opens the dialog
- Improved code clarity by adding a comment explaining the desktop-specific behavior

## Implementation Details
- Uses `window.matchMedia('(min-width: 640px)')` to detect desktop viewport
- Checks if the click target is within the task name cell using `row.cells[2]?.contains(target)`
- Early return prevents dialog from opening if the click is outside the task name cell on desktop
- Interactive elements (buttons, inputs, links, etc.) continue to be excluded from triggering the dialog on all devices

https://claude.ai/code/session_01U7f7XV3QGi1UqWmCBXwB4q