### PR TITLE
Move keyboard shortcut handling from TaskRow to TaskBoard

### DIFF
--- a/components/TaskBoard.tsx
+++ b/components/TaskBoard.tsx
@@ -464,6 +464,35 @@ export default function TaskBoard({ initialTasks, initialCollapsedIds, initialTh
     }
   }, [tasks, supabase, userId])
 
+  // ─── Ctrl+矢印キーでレベル上げ下げ（フォーカス位置問わず） ──────────
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (!e.ctrlKey) return
+      if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return
+
+      const target = e.target as HTMLElement
+      const tagName = target.tagName.toLowerCase()
+      if (tagName === 'textarea' || tagName === 'select') return
+      if (tagName === 'input' && (target as HTMLInputElement).type !== 'checkbox') return
+
+      const tr = target.closest('tr[data-task-id]')
+      if (!tr) return
+
+      const taskId = tr.getAttribute('data-task-id')
+      if (!taskId) return
+
+      e.preventDefault()
+      if (e.key === 'ArrowLeft') {
+        handleLevelUp(taskId)
+      } else {
+        handleLevelDown(taskId)
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [handleLevelUp, handleLevelDown])
+
   // ─── フォーカス設定 ──────────────────────────────────────────────────
   const handleFocus = useCallback((id: string, column: 'name' | 'due' | 'time' | 'checkbox') => {
     setFocusedId(id)

--- a/components/TaskRow.tsx
+++ b/components/TaskRow.tsx
@@ -76,16 +76,6 @@ export default memo(function TaskRow({
     setEditDialogOpen(true)
   }
 
-  const handleRowKeyDown = (e: React.KeyboardEvent) => {
-    if (e.ctrlKey && e.key === 'ArrowRight') {
-      e.preventDefault()
-      onLevelDown(task.id)
-    } else if (e.ctrlKey && e.key === 'ArrowLeft') {
-      e.preventDefault()
-      onLevelUp(task.id)
-    }
-  }
-
   const handleCheckboxKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault()
@@ -104,8 +94,8 @@ export default memo(function TaskRow({
       <tr
         ref={setNodeRef}
         style={style}
+        data-task-id={task.id}
         className={`border-b border-border-subtle group transition-[background-color,box-shadow] duration-150 ease-out hover:bg-surface-raised hover:shadow-[0_2px_8px_rgba(0,0,0,0.3)] cursor-pointer sm:cursor-default ${isDragging ? 'bg-accent-muted shadow-lg' : ''}`}
-        onKeyDown={handleRowKeyDown}
         onClick={handleRowClick}
       >
         {/* ドラッグハンドル */}


### PR DESCRIPTION
## Summary
Refactored the Ctrl+Arrow key handling for task level adjustment from individual TaskRow components to a centralized keyboard event listener in TaskBoard. This improves performance and simplifies the component hierarchy.

## Key Changes
- **Moved keyboard event logic**: Migrated `handleRowKeyDown` from TaskRow to a new `useEffect` hook in TaskBoard that listens for Ctrl+ArrowLeft/ArrowRight globally
- **Added data attribute**: Added `data-task-id` attribute to table rows to enable task identification from keyboard events
- **Improved event handling**: The new implementation:
  - Works regardless of focus position within the row
  - Prevents default behavior for text inputs and textareas (but allows checkboxes)
  - Uses event delegation to find the nearest task row
  - Properly cleans up event listeners on unmount

## Implementation Details
- The keyboard listener is attached to the document and uses `closest('tr[data-task-id]')` to identify which task row triggered the event
- Excludes textarea and select elements, and text-type inputs from triggering the shortcut
- Maintains the same keyboard shortcut behavior: Ctrl+ArrowLeft increases level, Ctrl+ArrowRight decreases level

https://claude.ai/code/session_015mmsVaSXQdRB6BwidpJZGK