### PR TITLE
Inherit due date settings from adjacent tasks

### DIFF
--- a/components/TaskBoard.tsx
+++ b/components/TaskBoard.tsx
@@ -294,18 +294,31 @@ export default function TaskBoard({ initialTasks, initialCollapsedIds, initialTh
       position = getNextPosition(siblings)
     }
 
-    // 親タスクの期日からデフォルト期日を計算
-    let defaultDueType: DueType = 'specific_date'
-    if (parentId) {
-      const parent = tasks.find(t => t.id === parentId)
-      if (parent) defaultDueType = getChildDefaultDueType(parent.due_type)
+    // 直上タスク（afterTaskId または兄弟の末尾）から期日設定を引き継ぐ
+    let aboveTask: Task | undefined
+    if (afterTaskId) {
+      aboveTask = tasks.find(t => t.id === afterTaskId)
+    } else if (siblings.length > 0) {
+      aboveTask = siblings[siblings.length - 1]
     }
 
-    // デフォルトの日付（今日）
-    const today = new Date()
-    const defaultDueDate = defaultDueType === 'specific_date'
-      ? `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`
-      : null
+    let defaultDueType: DueType
+    let defaultDueDate: string | null
+    if (aboveTask) {
+      defaultDueType = aboveTask.due_type
+      defaultDueDate = aboveTask.due_date
+    } else if (parentId) {
+      const parent = tasks.find(t => t.id === parentId)
+      defaultDueType = parent ? getChildDefaultDueType(parent.due_type) : 'specific_date'
+      const today = new Date()
+      defaultDueDate = defaultDueType === 'specific_date'
+        ? `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`
+        : null
+    } else {
+      defaultDueType = 'specific_date'
+      const today = new Date()
+      defaultDueDate = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`
+    }
 
     // 名前が確定されるまでローカルのみに保持する一時タスク
     const tempId = crypto.randomUUID()


### PR DESCRIPTION
## Summary
Modified the default due date logic for new tasks to inherit settings from the task directly above them (either the `afterTaskId` or the last sibling), rather than always deriving from the parent task or defaulting to today's date.

## Key Changes
- **Changed due date inheritance priority**: New tasks now first check for an adjacent task (`afterTaskId` or last sibling) and inherit both `due_type` and `due_date` from it
- **Fallback logic**: If no adjacent task exists, falls back to the previous behavior:
  - If parent task exists: derive `due_type` from parent using `getChildDefaultDueType()`, set `due_date` to today
  - Otherwise: default to `specific_date` type with today's date
- **Simplified logic flow**: Consolidated the due date calculation into a single conditional block with three clear branches

## Implementation Details
- The adjacent task lookup checks `afterTaskId` first, then falls back to the last element in the `siblings` array
- When inheriting from an adjacent task, both the `due_type` and `due_date` are copied directly, maintaining consistency within task sequences
- The date formatting logic for "today" is now only executed in the fallback cases where it's actually needed

https://claude.ai/code/session_01UwRXdHHhjro5XTLAjVreQ7